### PR TITLE
team name bug fixed. missing anchor tag close

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ canonical: https://robotruckus.org
             </div>
 
             <!-- Team Members 04 -->
-            <a name="battlebots"</a>
+            <a name="battlebots"></a>
             <div class="container">
                   <div class="team-members-tow mtb-50">
                     <h4>


### PR DESCRIPTION
found missing anchor tag closing chevron. this should fix the team name bug.